### PR TITLE
Crash when JSON-parsing empty string

### DIFF
--- a/lib/linter-crystal.js
+++ b/lib/linter-crystal.js
@@ -50,16 +50,18 @@ export default {
         args.push(activeEditor.getPath())
         resolve(helpers.exec(command, args).then(output => {
           const result = []
-          for (issue of JSON.parse(output)) {
-            result.push({
-              type: "error",
-              text: issue.message,
-              filePath: issue.file,
-              range: [
-                [issue.line - 1, issue.column -1 ],
-                [issue.line - 1, issue.column + issue.size - 1]
-              ]
-            })
+          if (output) {
+            for (issue of JSON.parse(output)) {
+              result.push({
+                type: "error",
+                text: issue.message,
+                filePath: issue.file,
+                range: [
+                  [issue.line - 1, issue.column - 1],
+                  [issue.line - 1, issue.column + issue.size - 1]
+                ]
+              })
+            }
           }
           return result
         }))


### PR DESCRIPTION
This fixes an issue which causes the following error when the edited crystal source file contains no errors:

```
SyntaxError: Unexpected end of input
  at Object.parse (native)
  at /home/pgkos/.atom/packages/linter-crystal/lib/linter-crystal.js:59:32
```
